### PR TITLE
add clearer error messages for mismatched types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,7 +73,7 @@
         "id-length": "off",
         "id-match": "error",
         "indent": "off",
-        "init-declarations": "error",
+        "init-declarations": "off",
         "jsx-quotes": "error",
         "key-spacing": "off",
         "keyword-spacing": "off",

--- a/ArrayValidator.js
+++ b/ArrayValidator.js
@@ -55,7 +55,7 @@ class ArrayValidator {
 
   assert (input) {
     if (!Array.isArray(input)){
-      throw error.MismatchedValue(input, this.toJSON());
+      throw new error.MismatchedValue(input, this.toJSON());
     }
     const schema = this.schema;
     const errors = [];
@@ -74,7 +74,7 @@ class ArrayValidator {
 
     if (schema.length || schema.length === 0){
       if (input.length !== schema.length){
-        const err = error.InvalidLength(input.length, schema.length);
+        const err = new error.InvalidLength(input.length, schema.length);
         errors.push(err);
       }
     }
@@ -84,7 +84,7 @@ class ArrayValidator {
       input.forEach(function(item, key){
         tested.push(key);
         if (matches[key] == null){
-          const err = error.UnexpectedValue(item, key);
+          const err = new error.UnexpectedValue(item, key);
           errors.push(err);
         } else {
           try {
@@ -100,7 +100,7 @@ class ArrayValidator {
       // those are the missing key / values on input
       matches.forEach(function(item, key){
         if (!tested.includes(key)){
-          const err = error.MissingValue(matches[key].toJSON(), key);
+          const err = new error.MissingValue(matches[key].toJSON(), key);
           errors.push(err);
         }
       });
@@ -108,7 +108,7 @@ class ArrayValidator {
 
     if (errors.length > 0){
       const expected = betterExpected(input, errors);
-      const err = error.MismatchedValue(input, expected);
+      const err = new error.MismatchedValue(input, expected);
       err.errors = errors;
       throw err;
     }

--- a/ArrayValidator.js
+++ b/ArrayValidator.js
@@ -172,6 +172,7 @@ function betterExpected(actual, errors) {
         invalidLengthError = error;
         break;
       case error.MismatchedValue:
+      case error.MismatchedType:
         if (error.key == null){
           throw new Error("no key for mismatch error");
         }

--- a/BooleanValidator.js
+++ b/BooleanValidator.js
@@ -36,7 +36,7 @@ class BooleanValidator {
    **/
   assert (input) {
     if (typeof input !== 'boolean'){
-      throw error.MismatchedValue(input, this.toJSON());
+      throw new error.MismatchedValue(input, this.toJSON());
     }
   }
 

--- a/DateValidator.js
+++ b/DateValidator.js
@@ -62,33 +62,33 @@ class DateValidator {
   assert (input) {
     const options = this.schema;
     if (!isValidDate(input)){
-      throw error.MismatchedValue(formatActual(input), this.toJSON());
+      throw new error.MismatchedValue(formatActual(input), this.toJSON());
     }
     if (options.equals != null){
       if (input.getTime() !== options.equals.getTime()){
-        throw error.MismatchedValue(formatActual(input), this.toJSON());
+        throw new error.MismatchedValue(formatActual(input), this.toJSON());
       }
     }
     if (options.recent != null){
       const tenSecondsAgo = new Date((new Date().getTime()) - (10 * 1000));
       if (options.recent === true){
         if (tenSecondsAgo > input){
-          throw error.MismatchedValue(formatActual(input), this.toJSON());
+          throw new error.MismatchedValue(formatActual(input), this.toJSON());
         }
       } else {
         if (tenSecondsAgo > input){
-          throw error.MismatchedValue(formatActual(input), this.toJSON());
+          throw new error.MismatchedValue(formatActual(input), this.toJSON());
         }
       }
     }
     if (options.before != null){
       if (input.getTime() >= options.before.getTime()){
-        throw error.MismatchedValue(formatActual(input), this.toJSON());
+        throw new error.MismatchedValue(formatActual(input), this.toJSON());
       }
     }
     if (options.after != null){
       if (input.getTime() <= options.after.getTime()){
-        throw error.MismatchedValue(formatActual(input), this.toJSON());
+        throw new error.MismatchedValue(formatActual(input), this.toJSON());
       }
     }
   }

--- a/NumberValidator.js
+++ b/NumberValidator.js
@@ -46,11 +46,11 @@ class NumberValidator {
   assert (input) {
     const options = this.schema;
     if (typeof input !== 'number'){
-      throw error.MismatchedValue(input, this.toJSON());
+      throw new error.MismatchedValue(input, this.toJSON());
     }
     if (options.integer === true){
       if (!Number.isInteger(input)){
-        throw error.MismatchedValue(input, this.toJSON());
+        throw new error.MismatchedValue(input, this.toJSON());
       }
     }
   }

--- a/OneOfValidator.js
+++ b/OneOfValidator.js
@@ -37,7 +37,7 @@ class OneOfValidator {
    **/
   assert (input) {
     if (!this.validators.some((v) => v.validate(input))){
-      throw error.MismatchedValue(input, this.toJSON());
+      throw new error.MismatchedValue(input, this.toJSON());
     }
   }
 

--- a/PlainObjectValidator.js
+++ b/PlainObjectValidator.js
@@ -220,6 +220,7 @@ function betterExpected(actual, errors) {
           delete expected[error.key];
           break;
         case error.MismatchedValue:
+        case error.MismatchedType:
           expected[error.key] = error.expected;
           break;
         default:

--- a/PlainObjectValidator.js
+++ b/PlainObjectValidator.js
@@ -20,7 +20,7 @@ function testObjectAgainstSchema (input, schema, options) {
     } catch (ex) {
       let err = ex;
       if (input[key] == null){
-        err = error.MissingValue(schema[key].toJSON(), key);
+        err = new error.MissingValue(schema[key].toJSON(), key);
       }
       err.key = key;
       errors.push(err);
@@ -32,7 +32,7 @@ function testObjectAgainstSchema (input, schema, options) {
     // those are the unexpected key / values on input
     for (const name in input){
       if (!tested.includes(name)){
-        const err = error.UnexpectedValue(input[name], name);
+        const err = new error.UnexpectedValue(input[name], name);
         errors.push(err);
       }
     }
@@ -102,7 +102,7 @@ class PlainObjectValidator {
         } catch (ex) {
           ex.errors.forEach(function(subError){
             errors.push(
-              InvalidKey(
+              new InvalidKey(
                 subError.actual,
                 subError.expected,
                 subError.actual
@@ -130,7 +130,7 @@ class PlainObjectValidator {
 
     if (errors.length > 0){
       const expected = betterExpected(input, errors);
-      const err = error.MismatchedValue(input, expected);
+      const err = new error.MismatchedValue(input, expected);
       err.errors = errors;
       throw err;
     }

--- a/SimpleNativeValidator.js
+++ b/SimpleNativeValidator.js
@@ -30,7 +30,7 @@ class SimpleNativeValidator {
    **/
   assert (input) {
     if (!this.validate(input)){
-      throw error.MismatchedValue(input, this.schema);
+      throw new error.MismatchedValue(input, this.schema);
     }
   }
 

--- a/StringValidator.js
+++ b/StringValidator.js
@@ -56,11 +56,11 @@ class StringValidator {
   assert (input) {
     const options = this.schema;
     if (!isString(input)){
-      throw error.MismatchedValue(input, this.toJSON());
+      throw new error.MismatchedValue(input, this.toJSON());
     }
     if (options.matches != null){
       if (!options.matches.test(input)){
-        throw error.MismatchedValue(input, this.toJSON());
+        throw new error.MismatchedValue(input, this.toJSON());
       }
     }
   }

--- a/error.js
+++ b/error.js
@@ -45,7 +45,24 @@ error.InvalidLength = function(actual, expected, key){
   return err;
 };
 
+error.MismatchedType = function(actual, expectedType, expected, key){
+  const err = new AssertionError(
+    `MismatchedType: expected ${JSON.stringify(actual)} (type ${typeName(actual)}) to be of type ${expectedType}`,
+    actual,
+    expected
+  );
+  err.MismatchedType = true;
+  if (key != null){
+    err.key = key;
+  }
+  return err;
+};
+
 error.MismatchedValue = function(actual, expected, key){
+  if (typeName(actual) !== typeName(expected)) {
+    return error.MismatchedType(actual, typeName(expected), expected, key);
+  }
+
   const err = new AssertionError(
     `MismatchedValue: expected ${JSON.stringify(actual)} to match ${JSON.stringify(expected)}`,
     actual,
@@ -71,5 +88,20 @@ error.UnexpectedValue = function(actual, key){
   err.key = key;
   return err;
 };
+
+function typeName (x) {
+  // if we have an object, it might be a JSON notation so we look for that first
+  if (x != null) {
+    const keys = Object.keys(x);
+    for (const key of keys) {
+      if (key[0] === "#") {
+        return key.slice(1);
+      }
+    }
+  }
+
+  return Object.prototype.toString.call(x).slice(8, -1).
+    toLowerCase();
+}
 
 module.exports = error;

--- a/error.js
+++ b/error.js
@@ -1,13 +1,16 @@
-let factory;
+let stackTraceBoundary;
 
 class AssertionError extends Error {
   constructor (message, actual, expected) {
-    if (factory == null) factory = require("./");
     super(message);
     this.actual = actual;
     this.expected = expected;
     this.showDiff = true;
-    Error.captureStackTrace(this, factory);
+    Error.captureStackTrace(this, stackTraceBoundary);
+  }
+
+  static setStackTraceBoundary (fn) {
+    stackTraceBoundary = fn;
   }
 }
 AssertionError.prototype.name = 'AssertionError';
@@ -94,6 +97,7 @@ function typeName (x) {
 }
 
 module.exports = {
+  AssertionError,
   InvalidKey,
   InvalidLength,
   MismatchedType,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const schemaToValidator = require('./schemaToValidator');
 const ArrayNotation = require('./ArrayNotation');
 const ObjectNotation = require('./ObjectNotation');
+const {AssertionError} = require('./error');
 
 class DateNotation {
   constructor () {
@@ -105,5 +106,7 @@ factory.log = function (actual, expected){
   }
   return null;
 };
+
+AssertionError.setStackTraceBoundary(factory);
 
 module.exports = factory;

--- a/test/BooleanValidator.js
+++ b/test/BooleanValidator.js
@@ -72,7 +72,7 @@ describe('BooleanValidator', function(){
       var expected = Boolean;
       var underTest = 14;
       var error = getError(underTest, expected);
-      expect(error.message).to.eql('MismatchedValue: expected 14 to match {"#boolean":{}}');
+      expect(error.message).to.eql('MismatchedType: expected 14 (type number) to be of type boolean');
       expect(error.expected).to.eql({'#boolean':{}});
       expect(error.actual).to.eql(14);
     });

--- a/test/SimpleNativeValidator.js
+++ b/test/SimpleNativeValidator.js
@@ -4,13 +4,14 @@ const testHelpers = require('../testHelpers');
 
 const expect = testHelpers.expect;
 const expectValueErrorToThrow = testHelpers.expectValueErrorToThrow;
+const expectTypeMismatchToThrow = testHelpers.expectTypeMismatchToThrow;
 
 function testLiteral(schema, unmatched){
   it ('throws error on unmatched value', function(){
     expectValueErrorToThrow(schema, unmatched);
   });
   it ('throws missing error on null', function(){
-    expectValueErrorToThrow(schema, null);
+    expectTypeMismatchToThrow(schema, null);
   });
   it ("identifies simple natives", function(){
     expect(SimpleNativeValidator.identify(schema)).to.eql(true);
@@ -36,7 +37,7 @@ describe('SimpleNativeValidator', function(){
         new SimpleNativeValidator(null).assert(false);
         throw new Error("expected exception was not raised");
       } catch (ex) {
-        expect(ex.message).to.eql('MismatchedValue: expected false to match null');
+        expect(ex.message).to.eql('MismatchedType: expected false (type boolean) to be of type null');
         expect(ex.actual).to.eql(false);
         expect(ex.expected).to.eql(null);
       }

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,10 @@ const liken = require('../index');
 var expect = require('chai').expect;
 // TODO what about default values?!?
 
+// const {
+//   expectTypeMismatchToThrow,
+// } = require("../testHelpers");
+
 function raise(fn){
   try {
     fn();
@@ -66,7 +70,7 @@ describe('liken (index.js)', function(){
         liken(undefined, 42);
       });
       expect(ex).to.be.an.instanceof(Error);
-      expect(ex.message).to.eql('MismatchedValue: expected undefined to match 42');
+      expect(ex.message).to.eql('MismatchedType: expected undefined (type undefined) to be of type number');
       expect(ex.actual).to.eql(undefined);
       expect(ex.expected).to.eql(42);
     });
@@ -75,7 +79,7 @@ describe('liken (index.js)', function(){
         liken(null, 42);
       });
       expect(ex).to.be.an.instanceof(Error);
-      expect(ex.message).to.eql('MismatchedValue: expected null to match 42');
+      expect(ex.message).to.eql('MismatchedType: expected null (type null) to be of type number');
       expect(ex.actual).to.eql(null);
       expect(ex.expected).to.eql(42);
     });

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,9 @@ describe('liken (index.js)', function(){
           firstName: String
         });
       });
+      const firstFrame = ex.stack.split("\n").slice(1).
+        shift();
+      expect(firstFrame).to.include("liken/test/index");
       expect(ex).to.be.an.instanceof(Error);
       expect(ex.message).to.eql('MismatchedValue: expected {"firstName":1234} to match {"firstName":{"#string":{}}}');
       expect(ex.errors).to.have.length(1);

--- a/test/literals.js
+++ b/test/literals.js
@@ -1,17 +1,19 @@
 var liken = require('../index');
 const testHelpers = require('../testHelpers');
 
-const expect = testHelpers.expect;
-const expectValueErrorToThrow = testHelpers.expectValueErrorToThrow;
-const getError = testHelpers.getError;
+const {
+  expect,
+  getError,
+  expectTypeMismatchToThrow,
+} = testHelpers;
 
 describe('liken literals', function(){
   describe("arrays of literals", function(){
     it ('throws error on wrong type', function(){
-      expectValueErrorToThrow([], 'asdf', {'#array':{"matches":[]}});
+      expectTypeMismatchToThrow([], 'asdf', {'#array':{"matches":[]}});
     });
     it ('throws value error on null', function(){
-      expectValueErrorToThrow([], null, {'#array':{"matches":[]}});
+      expectTypeMismatchToThrow([], null, {'#array':{"matches":[]}});
     });
     it ('allows matching values', function(){
       liken([], []);

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -70,12 +70,10 @@ function expectValueErrorToThrow(schema, wrongType, notation){
   expect(error.actual).to.eql(wrongType);
 }
 
-
-function expectTypeMismatchToThrow(schema, wrongVal, expectedType, actualType){
-  var error = getError(wrongVal, schema);
-  expectProperties(error, {
-    subType: 'invalid type', path: null, value: wrongVal, expectedValue: schema, expectedType: expectedType, actualType: actualType
-  });
+function expectTypeMismatchToThrow(schema, wrongType, notation){
+  var error = getError(wrongType, schema);
+  expect(error.message).to.eql(`MismatchedType: expected ${JSON.stringify(wrongType)} (type ${typeName(wrongType)}) to be of type ${typeName(schema || notation)}`);
+  expect(error.actual).to.eql(wrongType);
 }
 
 var assertObjectEquals = function (actual, expected, options){
@@ -124,6 +122,21 @@ var assertObjectEquals = function (actual, expected, options){
   }
   return true;
 };
+
+function typeName (x) {
+  // if we have an object, it might be a JSON notation so we look for that first
+  if (x != null) {
+    const keys = Object.keys(x);
+    for (const key of keys) {
+      if (key[0] === "#") {
+        return key.slice(1);
+      }
+    }
+  }
+
+  return Object.prototype.toString.call(x).slice(8, -1).
+    toLowerCase();
+}
 
 module.exports = {
   expect,


### PR DESCRIPTION
@cainus The following tests are currently broken, but I've left them like this to demonstrate the old output vs the new output. Please review and comment, and if acceptable I will fix up these broken test cases.

```
 1) BooleanValidator #assert throws on non-matching booleans:

      expected 'MismatchedType
      + expected - actual

      -MismatchedType: expected 14 (type number) to be of type boolean
      +MismatchedValue: expected 14 to match {"#boolean":{}}

      at Context.<anonymous> (test/BooleanValidator.js:75:32)

  2) SimpleNativeValidator with strings throws missing error on null:

      expected 'MismatchedType
      + expected - actual

      -MismatchedType: expected null (type null) to be of type string
      +MismatchedValue: expected null to match "a string"

      at expectValueErrorToThrow (testHelpers.js:69:28)
      at Context.<anonymous> (test/SimpleNativeValidator.js:13:5)

  3) SimpleNativeValidator number throws missing error on null:

      expected 'MismatchedType
      + expected - actual

      -MismatchedType: expected null (type null) to be of type number
      +MismatchedValue: expected null to match 12

      at expectValueErrorToThrow (testHelpers.js:69:28)
      at Context.<anonymous> (test/SimpleNativeValidator.js:13:5)

  4) SimpleNativeValidator null throws error on unmatched value:

      expected 'MismatchedType
      + expected - actual

      -MismatchedType: expected false (type boolean) to be of type null
      +MismatchedValue: expected false to match null

      at Context.<anonymous> (test/SimpleNativeValidator.js:39:31)

  5) SimpleNativeValidator boolean throws missing error on null:

      expected 'MismatchedType
      + expected - actual

      -MismatchedType: expected null (type null) to be of type boolean
      +MismatchedValue: expected null to match true

      at expectValueErrorToThrow (testHelpers.js:69:28)
      at Context.<anonymous> (test/SimpleNativeValidator.js:13:5)

  6) liken (index.js) validate errors when expecting a number but getting undefined:

      expected 'MismatchedType
      + expected - actual

      -MismatchedType: expected undefined (type undefined) to be of type number
      +MismatchedValue: expected undefined to match 42

      at Context.<anonymous> (test/index.js:66:29)

  7) liken (index.js) validate errors when expecting a number but getting null:

      expected 'MismatchedType
      + expected - actual

      -MismatchedType: expected null (type null) to be of type number
      +MismatchedValue: expected null to match 42

      at Context.<anonymous> (test/index.js:75:29)

  8) liken literals arrays of literals throws error on wrong type:

      expected 'MismatchedType
      + expected - actual

      -MismatchedType: expected "asdf" (type string) to be of type array
      +MismatchedValue: expected "asdf" to match {"#array":{"matches":[]}}

      at expectValueErrorToThrow (testHelpers.js:69:28)
      at Context.<anonymous> (test/literals.js:11:7)

  9) liken literals arrays of literals throws value error on null:

      expected 'MismatchedType
      + expected - actual

      -MismatchedType: expected null (type null) to be of type array
      +MismatchedValue: expected null to match {"#array":{"matches":[]}}

      at expectValueErrorToThrow (testHelpers.js:69:28)
      at Context.<anonymous> (test/literals.js:14:7)
```