### PR TITLE
simplify handling of primitives

### DIFF
--- a/SimpleNativeValidator.js
+++ b/SimpleNativeValidator.js
@@ -45,18 +45,8 @@ class SimpleNativeValidator {
    * returns true if this validator should be used.
    */
   static identify (schema) {
-    if (schema === null){
-      return true;
-    }
-    if (['number', 'boolean'].indexOf(typeof schema) !== -1){
-      return true;
-    }
-    if ((typeof schema === 'string') || (schema instanceof String)){
-      return true;
-    }
-    return false;
+    return Object(schema) !== schema;
   }
-
 }
 
 module.exports = SimpleNativeValidator;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ class DateNotation {
       '#date': this['#date']
     };
   }
-
 }
 
 class NumberNotation {

--- a/schemaToValidator.js
+++ b/schemaToValidator.js
@@ -49,7 +49,7 @@ function schemaToValidator (schema, extraValidators) {
       });
     }
     // check the schema for the right validator
-    for (const validator of validators){
+    for (const validator of validators) {
       if (validator.identify(schema)){
         // return a matching validator for this schema
         const retval = new validator(schema);

--- a/test/index.js
+++ b/test/index.js
@@ -216,6 +216,9 @@ describe('liken (index.js)', function(){
         throw ex;
       }
     });
+    it ('handles undefined', function(){
+      liken({ asdf: undefined }, { asdf: undefined });
+    });
     it ('returns true when an optional parameter is missing', function(){
       const optional = liken.optional;
       liken({


### PR DESCRIPTION
`Object(x) !== x` is a terse idiom for detecting if something is a primitive value

I removed the handling for `schema instanceof String` since it seems like that case should either be extended to `schema instanceof Boolean` and `schema instanceof Number` or removed entirely, with the second option being simpler. Further, there was not a test on it.

If you want the same behavior for `undefined` without accepting these changes, the added test will pass if you change `=== null` on L48 to `== null`.